### PR TITLE
fix: 🐛 Docker の Ruby のイメージのバージョンタグを 3.1.2 に戻した

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.3
+FROM ruby:3.1.2
 ENV LANG C.UTF-8
 
 RUN apt update -qq && apt install -y build-essential libpq-dev nodejs


### PR DESCRIPTION
v3.1.3 は現時点ではリリースされていないため
