### PR TITLE
Revert "fix: 🐛 Docker の Ruby のイメージのバージョンタグを 3.1.2 に戻した (#76)"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.1.2
+FROM ruby:3.1.3
 ENV LANG C.UTF-8
 
 RUN apt update -qq && apt install -y build-essential libpq-dev nodejs


### PR DESCRIPTION
This reverts commit 1718f7bc027a1dde1a099d15d4b8495c7f0a96da.
